### PR TITLE
fix: await mongoose connection

### DIFF
--- a/config/db.config.js
+++ b/config/db.config.js
@@ -5,7 +5,7 @@ const dbUrl = process.env.DB_URL;
 
 const connectDB = async () => {
   try {
-    mongoose.connect(dbUrl);
+    await mongoose.connect(dbUrl);
     console.log("✅ Database connected");
   } catch (e) {
     console.error("❌ Error connecting to database");


### PR DESCRIPTION
## Summary
- await mongoose connection to properly handle connection errors

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a47ac6ded88321a731b49ad73ed2e3