### PR TITLE
feat: add admin/technician roles with technician management

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import vrmRoutes from "./routes/vrm.routes.js";
 import inspectionRoutes from "./routes/inspection.routes.js";
+import technicianRoutes from "./routes/technician.routes.js";
 import session from "express-session";
 import MongoStore from "connect-mongo";
 import User from "./models/user.model.js";
@@ -89,5 +90,6 @@ app.get("/", (req, res) => {
 
 app.use("/vrm", vrmRoutes);
 app.use("/inspections", inspectionRoutes);
+app.use("/technicians", technicianRoutes);
 
 export default app;

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -40,7 +40,7 @@ export const postRegister = async (req, res) => {
     const saltRounds = 10;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    const user = await User.create({ name, email, passwordHash, dailyLimit });
+    const user = await User.create({ name, email, passwordHash, dailyLimit, role: "admin" });
 
     req.session.regenerate((err) => {
       if (err) return res.status(500).render("auth/register", { error: "Session error" });

--- a/controllers/dashboard.controller.js
+++ b/controllers/dashboard.controller.js
@@ -1,12 +1,20 @@
 // controllers/dashboard.controller.js
 import Inspection from "../models/inspection.model.js";
+import User from "../models/user.model.js";
 
 export const dashboard = async (req, res) => {
   const page = Math.max(1, Number(req.query.page || 1));
   const limit = 15;
   const skip = (page - 1) * limit;
 
-  const q = { user: req.user._id };
+  let q;
+  if (req.user.role === "admin") {
+    const techs = await User.find({ admin: req.user._id }).select("_id").lean();
+    const ids = [req.user._id, ...techs.map(t => t._id)];
+    q = { user: { $in: ids } };
+  } else {
+    q = { user: req.user._id };
+  }
   const [items, total] = await Promise.all([
     Inspection.find(q).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
     Inspection.countDocuments(q),
@@ -16,7 +24,10 @@ export const dashboard = async (req, res) => {
   const now = new Date();
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
   const end   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0));
-  const usedToday = await Inspection.countDocuments({ user: req.user._id, createdAt: { $gte: start, $lt: end } });
+  const usedToday = await Inspection.countDocuments({
+    user: q.user,
+    createdAt: { $gte: start, $lt: end }
+  });
   const dailyLimit = typeof req.user.dailyLimit === "number" ? req.user.dailyLimit : 0;
   const remaining = dailyLimit > 0 ? Math.max(0, dailyLimit - usedToday) : "∞";
 

--- a/controllers/technician.controller.js
+++ b/controllers/technician.controller.js
@@ -1,0 +1,23 @@
+// controllers/technician.controller.js
+import User from "../models/user.model.js";
+import bcrypt from "bcrypt";
+
+export const getNewTechnician = (req, res) => {
+  res.render("technicians/new");
+};
+
+export const createTechnician = async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    const existing = await User.countDocuments({ admin: req.user._id });
+    const limit = req.user.plan === "paid" ? 5 : 1;
+    if (existing >= limit) {
+      return res.status(403).render("technicians/new", { error: `Technician limit reached (${limit})` });
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    await User.create({ name, email, passwordHash, role: "technician", admin: req.user._id });
+    res.redirect("/dashboard");
+  } catch (e) {
+    res.status(400).render("technicians/new", { error: "Could not create technician" });
+  }
+};

--- a/middleware/requireAdmin.js
+++ b/middleware/requireAdmin.js
@@ -1,0 +1,7 @@
+// middleware/requireAdmin.js
+export default function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return res.status(403).send("Forbidden");
+  }
+  next();
+}

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -9,13 +9,16 @@ const userSchema = new Schema(
     name: { type: String, trim: true },
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     passwordHash: { type: String, required: true },
-    dailyLimit: { type: Number, default: 20, min: 0 },   // per-user limit
-    role: { type: String, enum: ["user", "admin"], default: "user" },
+    dailyLimit: { type: Number, default: 20, min: 0 }, // per-user limit
+    role: { type: String, enum: ["admin", "technician"], default: "technician" },
+    plan: { type: String, enum: ["free", "paid"], default: "free" },
+    admin: { type: Schema.Types.ObjectId, ref: "User", default: null }, // owning admin for technicians
   },
   { timestamps: true, versionKey: false }
 );
 
 userSchema.index({ email: 1 }, { unique: true });
+userSchema.index({ admin: 1 });
 
 userSchema.methods.setPassword = async function (plain) {
   this.passwordHash = await bcrypt.hash(plain, 12);

--- a/routes/technician.routes.js
+++ b/routes/technician.routes.js
@@ -1,0 +1,12 @@
+// routes/technician.routes.js
+import express from "express";
+import { getNewTechnician, createTechnician } from "../controllers/technician.controller.js";
+import requireAuth from "../middleware/requireAuth.js";
+import requireAdmin from "../middleware/requireAdmin.js";
+
+const router = express.Router();
+
+router.get("/new", requireAuth, requireAdmin, getNewTechnician);
+router.post("/", requireAuth, requireAdmin, createTechnician);
+
+export default router;

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -53,7 +53,10 @@
         </a>
 
         <!-- If your app expects POST for logout, convert this to a small form -->
-        <div class="text-sm">
+        <div class="text-sm flex gap-4 items-center">
+          <% if (user && user.role === 'admin') { %>
+            <a href="/technicians/new" class="text-slate-700 hover:text-slate-900">Add technician</a>
+          <% } %>
           <a href="/logout" class="text-slate-700 hover:text-slate-900">Logout</a>
         </div>
       </div>

--- a/views/technicians/new.ejs
+++ b/views/technicians/new.ejs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-slate-50">
+  <head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Add technician</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="h-full">
+    <%- include('../partials/topnav') %>
+
+    <main class="mx-auto max-w-md px-4 py-10">
+      <h1 class="text-xl font-semibold text-slate-900 mb-4">Add technician</h1>
+
+      <% if (typeof error !== 'undefined') { %>
+        <div class="mb-3 rounded border border-rose-300 bg-rose-50 text-rose-700 px-3 py-2"><%= error %></div>
+      <% } %>
+
+      <form method="POST" action="/technicians" class="space-y-3">
+        <input name="name" type="text" placeholder="Name" class="w-full rounded border border-slate-300 px-3 py-2"/>
+        <input name="email" type="email" required placeholder="Email" class="w-full rounded border border-slate-300 px-3 py-2"/>
+        <input name="password" type="password" required placeholder="Password" class="w-full rounded border border-slate-300 px-3 py-2"/>
+        <button class="w-full rounded bg-sky-600 text-white px-4 py-2 font-medium hover:bg-sky-700">Create</button>
+      </form>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- support admin and technician roles with account plans
- show admin all their technicians' inspections on dashboard
- allow admins to create technicians with plan-based limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a47d0f27b083219e0cecfdd41a5c8f