### PR TITLE
feat: add admin and technician roles

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import vrmRoutes from "./routes/vrm.routes.js";
 import inspectionRoutes from "./routes/inspection.routes.js";
+import technicianRoutes from "./routes/technician.routes.js";
 import session from "express-session";
 import MongoStore from "connect-mongo";
 import User from "./models/user.model.js";
@@ -89,5 +90,6 @@ app.get("/", (req, res) => {
 
 app.use("/vrm", vrmRoutes);
 app.use("/inspections", inspectionRoutes);
+app.use("/technicians", technicianRoutes);
 
 export default app;

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -40,7 +40,14 @@ export const postRegister = async (req, res) => {
     const saltRounds = 10;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    const user = await User.create({ name, email, passwordHash, dailyLimit });
+    const user = await User.create({
+      name,
+      email,
+      passwordHash,
+      dailyLimit,
+      role: "admin",
+      accountStatus: "free",
+    });
 
     req.session.regenerate((err) => {
       if (err) return res.status(500).render("auth/register", { error: "Session error" });

--- a/controllers/dashboard.controller.js
+++ b/controllers/dashboard.controller.js
@@ -1,12 +1,19 @@
 // controllers/dashboard.controller.js
 import Inspection from "../models/inspection.model.js";
+import User from "../models/user.model.js";
 
 export const dashboard = async (req, res) => {
   const page = Math.max(1, Number(req.query.page || 1));
   const limit = 15;
   const skip = (page - 1) * limit;
 
-  const q = { user: req.user._id };
+  let userIds = [req.user._id];
+  if (req.user.role === "admin") {
+    const techs = await User.find({ admin: req.user._id }, "_id").lean();
+    userIds = userIds.concat(techs.map((t) => t._id));
+  }
+
+  const q = { user: { $in: userIds } };
   const [items, total] = await Promise.all([
     Inspection.find(q).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
     Inspection.countDocuments(q),
@@ -16,7 +23,7 @@ export const dashboard = async (req, res) => {
   const now = new Date();
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
   const end   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0));
-  const usedToday = await Inspection.countDocuments({ user: req.user._id, createdAt: { $gte: start, $lt: end } });
+  const usedToday = await Inspection.countDocuments({ user: { $in: userIds }, createdAt: { $gte: start, $lt: end } });
   const dailyLimit = typeof req.user.dailyLimit === "number" ? req.user.dailyLimit : 0;
   const remaining = dailyLimit > 0 ? Math.max(0, dailyLimit - usedToday) : "∞";
 

--- a/controllers/technician.controller.js
+++ b/controllers/technician.controller.js
@@ -1,0 +1,25 @@
+// controllers/technician.controller.js
+import User from "../models/user.model.js";
+import bcrypt from "bcrypt";
+
+const TECH_LIMITS = {
+  free: 1,
+  paid: 10,
+};
+
+export const createTechnician = async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    const limit = TECH_LIMITS[req.user.accountStatus] ?? 0;
+    const count = await User.countDocuments({ admin: req.user._id, role: "technician" });
+    if (limit && count >= limit) {
+      return res.status(403).send("Technician limit reached");
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    await User.create({ name, email, passwordHash, role: "technician", admin: req.user._id });
+    return res.status(201).json({ message: "Technician created" });
+  } catch (e) {
+    console.error(e);
+    return res.status(400).send("Failed to create technician");
+  }
+};

--- a/middleware/requireAdmin.js
+++ b/middleware/requireAdmin.js
@@ -1,0 +1,7 @@
+// middleware/requireAdmin.js
+export default function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return res.status(403).send("Forbidden");
+  }
+  next();
+}

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -10,7 +10,12 @@ const userSchema = new Schema(
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     passwordHash: { type: String, required: true },
     dailyLimit: { type: Number, default: 20, min: 0 },   // per-user limit
-    role: { type: String, enum: ["user", "admin"], default: "user" },
+    // role based access control
+    role: { type: String, enum: ["admin", "technician"], default: "technician" },
+    // when a technician is created by an admin, store the admin's id
+    admin: { type: Schema.Types.ObjectId, ref: "User" },
+    // subscription tier controls how many technicians an admin can create
+    accountStatus: { type: String, enum: ["free", "paid"], default: "free" },
   },
   { timestamps: true, versionKey: false }
 );

--- a/routes/technician.routes.js
+++ b/routes/technician.routes.js
@@ -1,0 +1,11 @@
+// routes/technician.routes.js
+import express from "express";
+import { createTechnician } from "../controllers/technician.controller.js";
+import requireAuth from "../middleware/requireAuth.js";
+import requireAdmin from "../middleware/requireAdmin.js";
+
+const router = express.Router();
+
+router.post("/", requireAuth, requireAdmin, createTechnician);
+
+export default router;


### PR DESCRIPTION
## Summary
- add role, admin ownership and subscription fields to users
- show admin dashboard with technicians' inspections
- allow admins to create technicians with limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a47ede226c8321a5dfcf43121e8db8