### PR TITLE
feat: add admin and technician roles

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import vrmRoutes from "./routes/vrm.routes.js";
 import inspectionRoutes from "./routes/inspection.routes.js";
+import technicianRoutes from "./routes/technician.routes.js";
 import session from "express-session";
 import MongoStore from "connect-mongo";
 import User from "./models/user.model.js";
@@ -89,5 +90,6 @@ app.get("/", (req, res) => {
 
 app.use("/vrm", vrmRoutes);
 app.use("/inspections", inspectionRoutes);
+app.use("/technicians", technicianRoutes);
 
 export default app;

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -40,7 +40,14 @@ export const postRegister = async (req, res) => {
     const saltRounds = 10;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    const user = await User.create({ name, email, passwordHash, dailyLimit });
+    const user = await User.create({
+      name,
+      email,
+      passwordHash,
+      dailyLimit,
+      role: "admin",
+      accountStatus: "free",
+    });
 
     req.session.regenerate((err) => {
       if (err) return res.status(500).render("auth/register", { error: "Session error" });

--- a/controllers/dashboard.controller.js
+++ b/controllers/dashboard.controller.js
@@ -1,12 +1,19 @@
 // controllers/dashboard.controller.js
 import Inspection from "../models/inspection.model.js";
+import User from "../models/user.model.js";
 
 export const dashboard = async (req, res) => {
   const page = Math.max(1, Number(req.query.page || 1));
   const limit = 15;
   const skip = (page - 1) * limit;
 
-  const q = { user: req.user._id };
+  let userIds = [req.user._id];
+  if (req.user.role === "admin") {
+    const techs = await User.find({ admin: req.user._id }, "_id").lean();
+    userIds = userIds.concat(techs.map((t) => t._id));
+  }
+
+  const q = { user: { $in: userIds } };
   const [items, total] = await Promise.all([
     Inspection.find(q).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
     Inspection.countDocuments(q),
@@ -16,7 +23,7 @@ export const dashboard = async (req, res) => {
   const now = new Date();
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
   const end   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0));
-  const usedToday = await Inspection.countDocuments({ user: req.user._id, createdAt: { $gte: start, $lt: end } });
+  const usedToday = await Inspection.countDocuments({ user: { $in: userIds }, createdAt: { $gte: start, $lt: end } });
   const dailyLimit = typeof req.user.dailyLimit === "number" ? req.user.dailyLimit : 0;
   const remaining = dailyLimit > 0 ? Math.max(0, dailyLimit - usedToday) : "∞";
 

--- a/controllers/technician.controller.js
+++ b/controllers/technician.controller.js
@@ -1,0 +1,72 @@
+// controllers/technician.controller.js
+import User from "../models/user.model.js";
+import bcrypt from "bcrypt";
+
+const TECH_LIMITS = {
+  free: 1,
+  paid: 10,
+};
+
+export const createTechnician = async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    const limit = TECH_LIMITS[req.user.accountStatus] ?? 0;
+    const count = await User.countDocuments({ admin: req.user._id, role: "technician" });
+    if (limit && count >= limit) {
+      return res.status(403).send("Technician limit reached");
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    await User.create({ name, email, passwordHash, role: "technician", admin: req.user._id });
+    // return HTML redirect for browser forms or JSON for API requests
+    if (req.headers.accept && req.headers.accept.includes("application/json")) {
+      return res.status(201).json({ message: "Technician created" });
+    }
+    return res.redirect("/technicians");
+  } catch (e) {
+    console.error(e);
+    return res.status(400).send("Failed to create technician");
+  }
+};
+
+export const listTechnicians = async (req, res) => {
+  const techs = await User.find({ admin: req.user._id, role: "technician" }).lean();
+  res.render("technicians", { title: "Technicians", techs });
+};
+
+export const updateTechnician = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { name, email, password } = req.body;
+    const tech = await User.findOne({ _id: id, admin: req.user._id, role: "technician" });
+    if (!tech) {
+      return res.status(404).send("Not found");
+    }
+    tech.name = name;
+    tech.email = email;
+    if (password) {
+      tech.passwordHash = await bcrypt.hash(password, 10);
+    }
+    await tech.save();
+    if (req.headers.accept && req.headers.accept.includes("application/json")) {
+      return res.json({ message: "Technician updated" });
+    }
+    return res.redirect("/technicians");
+  } catch (e) {
+    console.error(e);
+    return res.status(400).send("Failed to update technician");
+  }
+};
+
+export const deleteTechnician = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await User.deleteOne({ _id: id, admin: req.user._id, role: "technician" });
+    if (req.headers.accept && req.headers.accept.includes("application/json")) {
+      return res.json({ message: "Technician deleted" });
+    }
+    return res.redirect("/technicians");
+  } catch (e) {
+    console.error(e);
+    return res.status(400).send("Failed to delete technician");
+  }
+};

--- a/middleware/requireAdmin.js
+++ b/middleware/requireAdmin.js
@@ -1,0 +1,7 @@
+// middleware/requireAdmin.js
+export default function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return res.status(403).send("Forbidden");
+  }
+  next();
+}

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -10,7 +10,12 @@ const userSchema = new Schema(
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     passwordHash: { type: String, required: true },
     dailyLimit: { type: Number, default: 20, min: 0 },   // per-user limit
-    role: { type: String, enum: ["user", "admin"], default: "user" },
+    // role based access control
+    role: { type: String, enum: ["admin", "technician"], default: "technician" },
+    // when a technician is created by an admin, store the admin's id
+    admin: { type: Schema.Types.ObjectId, ref: "User" },
+    // subscription tier controls how many technicians an admin can create
+    accountStatus: { type: String, enum: ["free", "paid"], default: "free" },
   },
   { timestamps: true, versionKey: false }
 );

--- a/routes/technician.routes.js
+++ b/routes/technician.routes.js
@@ -1,0 +1,19 @@
+// routes/technician.routes.js
+import express from "express";
+import {
+  createTechnician,
+  listTechnicians,
+  updateTechnician,
+  deleteTechnician,
+} from "../controllers/technician.controller.js";
+import requireAuth from "../middleware/requireAuth.js";
+import requireAdmin from "../middleware/requireAdmin.js";
+
+const router = express.Router();
+
+router.get("/", requireAuth, requireAdmin, listTechnicians);
+router.post("/", requireAuth, requireAdmin, createTechnician);
+router.post("/:id/update", requireAuth, requireAdmin, updateTechnician);
+router.post("/:id/delete", requireAuth, requireAdmin, deleteTechnician);
+
+export default router;

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -41,7 +41,7 @@
         <p class="mt-3 text-slate-600">Create a new inspection or review your recent ones.</p>
 
         <!-- Create Inspection button + usage pill -->
-        <div class="mt-6 flex items-center justify-center gap-3">
+        <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
           <button
             type="button"
             data-open-modal
@@ -59,6 +59,12 @@
             </svg>
             <%= limited ? (noneLeft ? '0 left today' : (remaining + ' left today')) : 'Unlimited' %>
           </span>
+
+          <% if (user && user.role === 'admin') { %>
+            <a href="/technicians" class="inline-flex items-center gap-2 rounded-xl px-5 py-3 border border-slate-300 text-slate-700 hover:bg-slate-50">
+              Manage Technicians
+            </a>
+          <% } %>
         </div>
 
         <% if (limited) { %>

--- a/views/partials/topnav.ejs
+++ b/views/partials/topnav.ejs
@@ -8,6 +8,9 @@
     <div class="flex items-center gap-3">
       <% if (user) { %>
         <a href="/dashboard" class="text-slate-700 hover:text-slate-900">Dashboard</a>
+        <% if (user.role === 'admin') { %>
+          <a href="/technicians" class="text-slate-700 hover:text-slate-900">Technicians</a>
+        <% } %>
         <a href="/inspections/new" class="text-slate-700 hover:text-slate-900">New</a>
         <form method="POST" action="/logout" class="inline">
           <button class="rounded border border-slate-300 px-3 py-1.5 text-slate-700 hover:bg-slate-50">Logout</button>

--- a/views/technicians.ejs
+++ b/views/technicians.ejs
@@ -1,0 +1,57 @@
+<%- include('partials/head', { title: typeof title !== 'undefined' ? title : 'Technicians — Tyre Inspector' }) %>
+<%- include('partials/topnav') %>
+
+<main class="mx-auto max-w-4xl px-4 py-8 space-y-8">
+  <section class="rounded-2xl bg-white border border-slate-200 shadow-sm p-6">
+    <h1 class="text-2xl font-bold mb-4">Technicians</h1>
+    <form method="POST" action="/technicians" class="space-y-3 max-w-md">
+      <div>
+        <label class="block text-sm font-medium text-slate-700" for="name">Name</label>
+        <input id="name" name="name" required class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-slate-700" for="email">Email</label>
+        <input id="email" name="email" type="email" required class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-slate-700" for="password">Password</label>
+        <input id="password" name="password" type="password" required class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+      </div>
+      <button type="submit" class="rounded-lg bg-sky-600 text-white px-4 py-2 font-medium hover:bg-sky-700">Add technician</button>
+    </form>
+  </section>
+
+  <section class="rounded-2xl bg-white border border-slate-200 shadow-sm p-6">
+    <h2 class="text-lg font-semibold mb-4">Existing technicians</h2>
+    <% if (Array.isArray(techs) && techs.length) { %>
+      <div class="space-y-4">
+        <% techs.forEach(function(t){ %>
+          <div class="border border-slate-200 rounded-lg p-4 space-y-2">
+            <form method="POST" action="/technicians/<%= t._id %>/update" class="flex flex-wrap items-end gap-3">
+              <div class="flex-1 min-w-[120px]">
+                <label class="block text-xs font-medium text-slate-700">Name</label>
+                <input name="name" value="<%= t.name %>" required class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+              </div>
+              <div class="flex-1 min-w-[160px]">
+                <label class="block text-xs font-medium text-slate-700">Email</label>
+                <input name="email" type="email" value="<%= t.email %>" required class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+              </div>
+              <div class="flex-1 min-w-[140px]">
+                <label class="block text-xs font-medium text-slate-700">New password</label>
+                <input name="password" type="password" class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+              </div>
+              <button type="submit" class="rounded-lg bg-emerald-600 text-white px-3 py-2 font-medium hover:bg-emerald-700">Save</button>
+            </form>
+            <form method="POST" action="/technicians/<%= t._id %>/delete" class="mt-2" onsubmit="return confirm('Delete this technician?');">
+              <button class="text-rose-700 hover:underline" type="submit">Delete</button>
+            </form>
+          </div>
+        <% }) %>
+      </div>
+    <% } else { %>
+      <p class="text-slate-600">No technicians yet.</p>
+    <% } %>
+  </section>
+</main>
+
+<%- include('partials/scripts') %>


### PR DESCRIPTION
## Summary
- add role, admin ownership and subscription fields to users
- show admin dashboard with technicians' inspections
- allow admins to create, update, and delete technicians

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47ede226c8321a5dfcf43121e8db8