### PR TITLE
Add admin registration and technician management

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import MongoStore from "connect-mongo";
 
 import vrmRoutes from "./routes/vrm.routes.js";
 import inspectionRoutes from "./routes/inspection.routes.js";
+import technicianRoutes from "./routes/technician.routes.js";
 import User from "./models/user.model.js";
 import { getLogin, postLogin, getRegister, postRegister, postLogout } from "./controllers/auth.controller.js";
 import requireAuth from "./middleware/requireAuth.js";
@@ -95,5 +96,6 @@ app.get("/", (req, res) => {
 
 app.use("/vrm", vrmRoutes);
 app.use("/inspections", inspectionRoutes);
+app.use("/technicians", technicianRoutes);
 
 export default app;

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -40,7 +40,7 @@ export const postRegister = async (req, res) => {
     const saltRounds = 10;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    const user = await User.create({ name, email, passwordHash, dailyLimit });
+    const user = await User.create({ name, email, passwordHash, dailyLimit, role: "admin" });
 
     req.session.regenerate((err) => {
       if (err) return res.status(500).render("auth/register", { error: "Session error" });

--- a/src/controllers/dashboard.controller.js
+++ b/src/controllers/dashboard.controller.js
@@ -1,12 +1,19 @@
 // controllers/dashboard.controller.js
 import Inspection from "../models/inspection.model.js";
+import User from "../models/user.model.js";
 
 export const dashboard = async (req, res) => {
   const page = Math.max(1, Number(req.query.page || 1));
   const limit = 15;
   const skip = (page - 1) * limit;
 
-  const q = { user: req.user._id };
+  let userIds = [req.user._id];
+  if (req.user.role === "admin") {
+    const techs = await User.find({ admin: req.user._id }, "_id").lean();
+    userIds = userIds.concat(techs.map((t) => t._id));
+  }
+
+  const q = { user: { $in: userIds } };
   const [items, total] = await Promise.all([
     Inspection.find(q).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
     Inspection.countDocuments(q),
@@ -16,7 +23,7 @@ export const dashboard = async (req, res) => {
   const now = new Date();
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
   const end   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0));
-  const usedToday = await Inspection.countDocuments({ user: req.user._id, createdAt: { $gte: start, $lt: end } });
+  const usedToday = await Inspection.countDocuments({ user: { $in: userIds }, createdAt: { $gte: start, $lt: end } });
   const dailyLimit = typeof req.user.dailyLimit === "number" ? req.user.dailyLimit : 0;
   const remaining = dailyLimit > 0 ? Math.max(0, dailyLimit - usedToday) : "∞";
 

--- a/src/controllers/technician.controller.js
+++ b/src/controllers/technician.controller.js
@@ -1,0 +1,56 @@
+// controllers/technician.controller.js
+import bcrypt from "bcrypt";
+import User from "../models/user.model.js";
+
+export const listTechnicians = async (req, res) => {
+  const technicians = await User.find({ admin: req.user._id }).lean();
+  res.render("technicians/list", { technicians });
+};
+
+export const getCreateTechnician = (_req, res) => {
+  res.render("technicians/new");
+};
+
+export const postCreateTechnician = async (req, res) => {
+  try {
+    const { name, email, password, dailyLimit } = req.body;
+    const passwordHash = await bcrypt.hash(password, 10);
+    await User.create({
+      name,
+      email,
+      passwordHash,
+      dailyLimit: Number(dailyLimit) || 0,
+      role: "technician",
+      admin: req.user._id,
+    });
+    res.redirect("/technicians");
+  } catch (e) {
+    res.status(400).render("technicians/new", { error: "Failed to create technician" });
+  }
+};
+
+export const getEditTechnician = async (req, res) => {
+  const tech = await User.findOne({ _id: req.params.id, admin: req.user._id }).lean();
+  if (!tech) return res.status(404).send("Not found");
+  res.render("technicians/edit", { technician: tech });
+};
+
+export const postEditTechnician = async (req, res) => {
+  const tech = await User.findOne({ _id: req.params.id, admin: req.user._id });
+  if (!tech) return res.status(404).send("Not found");
+
+  const { name, email, password, dailyLimit } = req.body;
+  tech.name = name;
+  tech.email = email;
+  tech.dailyLimit = Number(dailyLimit) || 0;
+  if (password) {
+    tech.passwordHash = await bcrypt.hash(password, 10);
+  }
+  await tech.save();
+  res.redirect("/technicians");
+};
+
+export const postDeleteTechnician = async (req, res) => {
+  await User.deleteOne({ _id: req.params.id, admin: req.user._id });
+  res.redirect("/technicians");
+};

--- a/src/middleware/requireAdmin.js
+++ b/src/middleware/requireAdmin.js
@@ -1,0 +1,7 @@
+// middleware/requireAdmin.js
+export default function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return res.status(403).send("Forbidden");
+  }
+  next();
+}

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -10,7 +10,8 @@ const userSchema = new Schema(
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     passwordHash: { type: String, required: true },
     dailyLimit: { type: Number, default: 20, min: 0 },   // per-user limit
-    role: { type: String, enum: ["user", "admin"], default: "user" },
+    role: { type: String, enum: ["technician", "admin"], default: "technician" },
+    admin: { type: Schema.Types.ObjectId, ref: "User", index: true }, // owner for technicians
   },
   { timestamps: true, versionKey: false }
 );

--- a/src/routes/technician.routes.js
+++ b/src/routes/technician.routes.js
@@ -1,0 +1,24 @@
+import express from "express";
+import {
+  listTechnicians,
+  getCreateTechnician,
+  postCreateTechnician,
+  getEditTechnician,
+  postEditTechnician,
+  postDeleteTechnician,
+} from "../controllers/technician.controller.js";
+import requireAuth from "../middleware/requireAuth.js";
+import requireAdmin from "../middleware/requireAdmin.js";
+
+const router = express.Router();
+
+router.use(requireAuth, requireAdmin);
+
+router.get("/", listTechnicians);
+router.get("/new", getCreateTechnician);
+router.post("/", postCreateTechnician);
+router.get("/:id/edit", getEditTechnician);
+router.post("/:id", postEditTechnician);
+router.post("/:id/delete", postDeleteTechnician);
+
+export default router;

--- a/src/views/partials/topnav.ejs
+++ b/src/views/partials/topnav.ejs
@@ -9,6 +9,9 @@
       <% if (user) { %>
         <a href="/dashboard" class="text-slate-700 hover:text-slate-900">Dashboard</a>
         <a href="/inspections/new" class="text-slate-700 hover:text-slate-900">New</a>
+        <% if (user.role === 'admin') { %>
+          <a href="/technicians" class="text-slate-700 hover:text-slate-900">Technicians</a>
+        <% } %>
         <form method="POST" action="/logout" class="inline">
           <button class="rounded border border-slate-300 px-3 py-1.5 text-slate-700 hover:bg-slate-50">Logout</button>
         </form>

--- a/src/views/technicians/edit.ejs
+++ b/src/views/technicians/edit.ejs
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-slate-50">
+  <head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Edit Technician</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="h-full">
+    <%- include('../partials/topnav') %>
+    <main class="mx-auto max-w-md px-4 py-10">
+      <h1 class="text-xl font-semibold text-slate-900 mb-4">Edit Technician</h1>
+      <%- include('form', { action: '/technicians/' + technician._id, technician }) %>
+    </main>
+  </body>
+</html>

--- a/src/views/technicians/form.ejs
+++ b/src/views/technicians/form.ejs
@@ -1,0 +1,7 @@
+<form method="POST" action="<%= action %>" class="space-y-3">
+  <input name="name" type="text" placeholder="Name" class="w-full rounded border border-slate-300 px-3 py-2" value="<%= technician ? technician.name : '' %>" />
+  <input name="email" type="email" required placeholder="Email" class="w-full rounded border border-slate-300 px-3 py-2" value="<%= technician ? technician.email : '' %>" />
+  <input name="password" type="password" <%= technician ? '' : 'required' %> placeholder="Password" class="w-full rounded border border-slate-300 px-3 py-2" />
+  <input name="dailyLimit" type="number" min="0" placeholder="Daily limit" class="w-full rounded border border-slate-300 px-3 py-2" value="<%= technician ? technician.dailyLimit : 0 %>" />
+  <button class="w-full rounded bg-sky-600 text-white px-4 py-2 font-medium hover:bg-sky-700">Save</button>
+</form>

--- a/src/views/technicians/list.ejs
+++ b/src/views/technicians/list.ejs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-slate-50">
+  <head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Technicians</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="h-full">
+    <%- include('../partials/topnav') %>
+    <main class="mx-auto max-w-3xl px-4 py-10">
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold text-slate-900">Technicians</h1>
+        <a href="/technicians/new" class="rounded bg-sky-600 text-white px-3 py-2 text-sm font-medium hover:bg-sky-700">Add technician</a>
+      </div>
+      <table class="w-full text-left border-collapse">
+        <thead>
+          <tr class="border-b">
+            <th class="p-2">Name</th>
+            <th class="p-2">Email</th>
+            <th class="p-2">Daily limit</th>
+            <th class="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% technicians.forEach(t => { %>
+            <tr class="border-b">
+              <td class="p-2"><%= t.name %></td>
+              <td class="p-2"><%= t.email %></td>
+              <td class="p-2"><%= typeof t.dailyLimit === 'number' ? t.dailyLimit : '' %></td>
+              <td class="p-2 space-x-2">
+                <a href="/technicians/<%= t._id %>/edit" class="text-sky-700 underline">Edit</a>
+                <form method="POST" action="/technicians/<%= t._id %>/delete" class="inline" onsubmit="return confirm('Delete technician?');">
+                  <button class="text-rose-700 underline">Delete</button>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>

--- a/src/views/technicians/new.ejs
+++ b/src/views/technicians/new.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-slate-50">
+  <head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>New Technician</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="h-full">
+    <%- include('../partials/topnav') %>
+    <main class="mx-auto max-w-md px-4 py-10">
+      <h1 class="text-xl font-semibold text-slate-900 mb-4">New Technician</h1>
+      <% if (typeof error !== 'undefined') { %>
+        <div class="mb-3 rounded border border-rose-300 bg-rose-50 text-rose-700 px-3 py-2"><%= error %></div>
+      <% } %>
+      <%- include('form', { action: '/technicians', technician: null }) %>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- make registrations create admin accounts
- allow admins to create, edit and delete technicians with daily usage limits
- show all inspections for an admin's technicians on the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a49b622a8c83218d87890eae391a25